### PR TITLE
updated create identity to check if email is already used by an activ…

### DIFF
--- a/api/response_writer.go
+++ b/api/response_writer.go
@@ -22,6 +22,7 @@ var (
 		identity.ErrEmailValidation:     http.StatusBadRequest,
 		identity.ErrPasswordValidation:  http.StatusBadRequest,
 		identity.ErrIdentityNil:         http.StatusBadRequest,
+		identity.ErrEmailAlreadyExists:  http.StatusBadRequest,
 	}
 
 	newTokenResponse = JSONResponseWriter{

--- a/identity/service.go
+++ b/identity/service.go
@@ -15,7 +15,7 @@ var (
 	ErrPasswordValidation = ValidationErr{message: "mandatory field password was empty"}
 	ErrAuthenticateFailed = errors.New("authentication unsuccessful")
 	ErrEmailAlreadyExists = errors.New("active identity already exists with email")
-	ErrIdentityNotFound   = errors.New("authentication unsuccessful identity not found")
+	ErrIdentityNotFound   = errors.New("authentication unsuccessful user not found")
 )
 
 func (s *Service) Validate(i *Model) (err error) {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -4,13 +4,15 @@ import (
 	"github.com/ONSdigital/dp-identity-api/config"
 	"github.com/globalsign/mgo"
 	"github.com/satori/go.uuid"
+	"gopkg.in/mgo.v2/bson"
 	"time"
 
 	"github.com/pkg/errors"
 )
 
 var (
-	ErrNotFound = errors.New("not found")
+	ErrNotFound  = errors.New("not found")
+	ErrNonUnique = errors.New("non unique")
 )
 
 // Mongo represents a simplistic MongoDB configuration.
@@ -58,11 +60,21 @@ func (m *Mongo) Create(identity Identity) (string, error) {
 	s := m.Session.Copy()
 	defer s.Close()
 
+	available, err := m.identityAvailable(s, identity.Email);
+	if err != nil {
+		return "", err
+	}
+
+	if !available {
+		return "", ErrNonUnique
+	}
+
 	// NOTE - Upsert may be more appropriate than Insert. Consider "already exists" scenarios?
 	id, err := uuid.NewV4()
 	if err != nil {
 		return "", errors.Wrap(err, "error generating uuid")
 	}
+
 	identity.ID = id.String()
 
 	err = s.DB(m.Database).C(m.Collection).Insert(identity)
@@ -74,5 +86,16 @@ func (m *Mongo) Create(identity Identity) (string, error) {
 		return "", err
 	}
 
-	return id.String(), nil
+	return identity.ID, nil
+}
+
+func (m *Mongo) identityAvailable(s *mgo.Session, email string) (bool, error) {
+	query := bson.M{"email": email, "deleted": false}
+
+	count, err := s.DB(m.Database).C(m.Collection).Find(query).Count()
+	if err != nil {
+		return false, errors.Wrap(err, "error executing count active identities query")
+	}
+
+	return count == 0, nil
 }


### PR DESCRIPTION
- Updated `mongo.Create` to check provided email is not associated with an active identity.
- Updated service and API handler to propagate error.
- Updated error mapping to return a `400` status.
- Unit tests to cover new functionality.