### PR TITLE
Spike/redis

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -20,5 +20,6 @@ func New(host string, identityService IdentityService, auditor audit.AuditorServ
 func (api *API) RegisterEndpoints(r *mux.Router) {
 	r.HandleFunc("/identity", api.CreateIdentityHandler).Methods("POST")
 	r.HandleFunc("/token", api.CreateTokenHandler).Methods("POST")
+	r.HandleFunc("/token/{token}", api.ping).Methods("POST")
 	r.Path("/healthcheck").HandlerFunc(healthcheck.Do)
 }

--- a/api/apitest/generate_mocks.go
+++ b/api/apitest/generate_mocks.go
@@ -23,7 +23,7 @@ var (
 //             CreateFunc: func(ctx context.Context, i *identity.Model) (string, error) {
 // 	               panic("TODO: mock out the Create method")
 //             },
-//             VerifyPasswordFunc: func(ctx context.Context, email string, password string) error {
+//             VerifyPasswordFunc: func(ctx context.Context, email string, password string) (*identity.Model, error) {
 // 	               panic("TODO: mock out the VerifyPassword method")
 //             },
 //         }
@@ -37,7 +37,7 @@ type IdentityServiceMock struct {
 	CreateFunc func(ctx context.Context, i *identity.Model) (string, error)
 
 	// VerifyPasswordFunc mocks the VerifyPassword method.
-	VerifyPasswordFunc func(ctx context.Context, email string, password string) error
+	VerifyPasswordFunc func(ctx context.Context, email string, password string) (*identity.Model, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -96,7 +96,7 @@ func (mock *IdentityServiceMock) CreateCalls() []struct {
 }
 
 // VerifyPassword calls VerifyPasswordFunc.
-func (mock *IdentityServiceMock) VerifyPassword(ctx context.Context, email string, password string) error {
+func (mock *IdentityServiceMock) VerifyPassword(ctx context.Context, email string, password string) (*identity.Model, error) {
 	if mock.VerifyPasswordFunc == nil {
 		panic("moq: IdentityServiceMock.VerifyPasswordFunc is nil but IdentityService.VerifyPassword was just called")
 	}

--- a/api/models.go
+++ b/api/models.go
@@ -34,6 +34,7 @@ type API struct {
 	IdentityService    IdentityService
 	healthCheckTimeout time.Duration
 	auditor            audit.AuditorService
+	Cache              Cache
 }
 
 //IdentityCreated is the HTTP response entity for create identity success.
@@ -81,5 +82,10 @@ func getNewTokenRequest(ctx context.Context, r io.ReadCloser) (*NewTokenRequest,
 //IdentityService is a service for creating, updating and deleting Identities.
 type IdentityService interface {
 	Create(ctx context.Context, i *identity.Model) (string, error)
-	VerifyPassword(ctx context.Context, email string, password string) error
+	VerifyPassword(ctx context.Context, email string, password string) (*identity.Model, error)
+}
+
+type Cache interface {
+	Set(token string, i identity.Model) error
+	Get(token string) (*identity.Model, error)
 }

--- a/api/ping.go
+++ b/api/ping.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+func (api *API) ping(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	token := vars["token"]
+
+	_, err := api.Cache.Get(token)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	return
+}

--- a/api/token.go
+++ b/api/token.go
@@ -57,7 +57,7 @@ func (api *API) CreateTokenHandler(w http.ResponseWriter, r *http.Request) {
 func (api *API) createToken(ctx context.Context, tokenReq *NewTokenRequest) (*AuthToken, error) {
 	logD := log.Data{"email": tokenReq.Email}
 
-	err := api.IdentityService.VerifyPassword(ctx, tokenReq.Email, tokenReq.Password)
+	i, err := api.IdentityService.VerifyPassword(ctx, tokenReq.Email, tokenReq.Password)
 	if err != nil {
 		log.ErrorCtx(ctx, errors.Wrap(err, "createToken: request unsuccessful"), logD)
 		return nil, err
@@ -67,6 +67,8 @@ func (api *API) createToken(ctx context.Context, tokenReq *NewTokenRequest) (*Au
 	if err != nil {
 		return nil, err
 	}
+
+	api.Cache.Set(token.String(), *i)
 
 	log.InfoCtx(ctx, "createToken: user credential successfully verified", logD)
 	return &AuthToken{Token: token.String()}, nil

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,100 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"github.com/ONSdigital/dp-identity-api/identity"
+	"github.com/ONSdigital/go-ns/log"
+	"github.com/gomodule/redigo/redis"
+	"github.com/pkg/errors"
+	"time"
+)
+
+var (
+	ErrTokenNotFound = errors.New("could not find token in cache")
+)
+
+func New(addr string) *IdentityCache {
+	pool := redis.Pool{
+		MaxIdle:     3,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			//return redis.Dial("tcp", ":6379")
+			return redis.Dial("tcp", addr)
+		},
+	}
+
+	return &IdentityCache{
+		ttl:  30,
+		pool: pool,
+	}
+
+}
+
+type IdentityCache struct {
+	pool redis.Pool
+	ttl  int
+}
+
+func (c *IdentityCache) Set(token string, i identity.Model) error {
+	conn := c.pool.Get()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	conn.Send("HMSET", redis.Args{token}.AddFlat(i)...)
+	conn.Send("EXPIRE", token, c.ttl)
+	r, err := conn.Do("EXEC")
+	if err != nil {
+		return err
+	}
+	fmt.Println(r)
+
+	return nil
+}
+
+func (c *IdentityCache) Get(token string) (*identity.Model, error) {
+	conn := c.pool.Get()
+	defer conn.Close()
+
+	// Create a transaction and queue the commands to update TTL and get the identity object.
+	conn.Send("MULTI")
+	conn.Send("EXPIRE", token, c.ttl)
+	conn.Send("HGETALL", token)
+
+	// execute the transaction
+	values, err := redis.Values(conn.Do("EXEC"))
+	if err != nil {
+		return nil, err
+	}
+
+	// get the EXPIRE response
+	expire, err := redis.Int64(values[0], nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// EXPIRE returns 1 if the TTL was set, 0 if the key did not exist.
+	if expire == 0 {
+		log.Info("redis key does not exist", nil)
+		return nil, ErrTokenNotFound
+	}
+
+	// get the response to HGETALL i.e. the identity object.
+	hgetall, err := redis.Values(values[1], nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert the response bytes into a struct
+	var i identity.Model
+	err = redis.ScanStruct(hgetall, &i)
+	if err != nil {
+		return nil, err
+	}
+	return &i, nil
+}
+
+func (c *IdentityCache) Close(ctx context.Context) error {
+	log.Info("closing IdentityCache", nil)
+	return c.pool.Close()
+}

--- a/identity/models.go
+++ b/identity/models.go
@@ -27,8 +27,8 @@ func (e ValidationErr) Error() string {
 
 //Service encapsulates the logic for creating, updating and deleting identities
 type Service struct {
-	DB        persistence.DB
-	Encryptor Encryptor
+	DB         persistence.DB
+	Encryptor  Encryptor
 }
 
 //Model is an object representation of a user identity.

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -14,7 +14,7 @@ import (
 var (
 	ErrNotFound  = errors.New("not found")
 	ErrNonUnique = errors.New("non unique")
-	nilIdentity = persistence.Identity{}
+	nilIdentity  = persistence.Identity{}
 )
 
 // Mongo represents a simplistic MongoDB configuration.
@@ -78,6 +78,7 @@ func (m *Mongo) SaveIdentity(identity persistence.Identity) (string, error) {
 	}
 
 	identity.ID = id.String()
+	identity.CreatedDate = time.Now()
 
 	err = s.DB(m.Database).C(m.Collection).Insert(identity)
 	if err == mgo.ErrNotFound {

--- a/persistence/models.go
+++ b/persistence/models.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"errors"
+	"time"
 )
 
 //go:generate moq -out persistencetest/generate_mocks.go -pkg persistencetest . DB
@@ -26,4 +27,5 @@ type Identity struct {
 	TemporaryPassword bool      `bson:"temporary_password"`
 	Migrated          bool      `bson:"migrated"`
 	Deleted           bool      `bson:"deleted"`
+	CreatedDate       time.Time `bson:"createdDate"`
 }


### PR DESCRIPTION
**DO NOT MERGE**
PR just used to show spike code.

- Basic Cache interface for Setting & Getting Identities / auth tokens. 
- IdentityCache implementation is for `Redis`.
- Uses `MULTI` to update the TTL and Get the identity in a single transaction.

Rest of changes can be ignored and were just required to be able to test the impl.

