### PR TITLE
updated status code for email already associated with active identity

### DIFF
--- a/api/create_identity_test.go
+++ b/api/create_identity_test.go
@@ -272,7 +272,7 @@ func TestAPI_CreateIdentityHandlerEmailAlreadyInUse(t *testing.T) {
 
 		identityAPI.CreateIdentityHandler(w, r)
 
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		So(w.Code, ShouldEqual, http.StatusConflict)
 		So(strings.TrimSpace(w.Body.String()), ShouldEqual, identity.ErrEmailAlreadyExists.Error())
 
 		So(serviceMock.CreateCalls(), ShouldHaveLength, 1)

--- a/api/response_writer.go
+++ b/api/response_writer.go
@@ -23,7 +23,7 @@ var (
 		schema.ErrEmailValidation:       http.StatusBadRequest,
 		schema.ErrPasswordValidation:    http.StatusBadRequest,
 		schema.ErrIdentityNil:           http.StatusBadRequest,
-		identity.ErrEmailAlreadyExists:  http.StatusBadRequest,
+		identity.ErrEmailAlreadyExists:  http.StatusConflict,
 	}
 
 	newTokenResponse = JSONResponseWriter{

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -44,6 +44,8 @@ paths:
             $ref: '#/definitions/IdentityCreated'
         400:
           description: "invalid request body"
+        409:
+          description: "email address is already associated with an active identity"
         500:
           description: "internal server error"
   /token:


### PR DESCRIPTION
Update status code, test and swagger spec for create identity - email already associated with an active identity.