### PR TITLE
Avoid shadowing token pkg

### DIFF
--- a/mongo/token_store.go
+++ b/mongo/token_store.go
@@ -9,6 +9,6 @@ func (m *Mongo) StoreToken(key string, i schema.Identity, ttl time.Duration) err
 	return nil
 }
 
-func (m *Mongo) GetToken(token string) (time.Duration, error) {
+func (m *Mongo) GetToken(tokenStr string) (time.Duration, error) {
 	return time.Second * 0, nil
 }

--- a/persistence/token_db_wrapper.go
+++ b/persistence/token_db_wrapper.go
@@ -24,10 +24,10 @@ func (c *CachedTokenStored) StoreToken(key string, i schema.Identity, ttl time.D
 	return c.TokenDB.StoreToken(key, i, ttl)
 }
 
-func (c *CachedTokenStored) GetToken(token string) (time.Duration, error) {
+func (c *CachedTokenStored) GetToken(tokenStr string) (time.Duration, error) {
 
 	// c.Cache.GetToken() ... etc
 	// implemented this sprint - for now we'll just fall through
 
-	return c.TokenDB.GetToken(token)
+	return c.TokenDB.GetToken(tokenStr)
 }


### PR DESCRIPTION
Renaming a string variable so it doesn't shadow the upcoming token package.

Anyone can review.