### PR TITLE
updated tokenstore interfaces to accept context as their first param

### DIFF
--- a/cache/nop_cache.go
+++ b/cache/nop_cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"github.com/ONSdigital/dp-identity-api/schema"
 	"github.com/ONSdigital/go-ns/log"
 	"time"
@@ -9,14 +10,14 @@ import (
 // NOPCache is a no op implementation of a cache.
 type NOPCache struct{}
 
-func (c *NOPCache) StoreToken(tkn schema.Token, i schema.Identity, ttl time.Duration) error {
+func (c *NOPCache) StoreToken(ctx context.Context, tkn schema.Token, i schema.Identity, ttl time.Duration) error {
 
 	log.Info("nopcache: store token", log.Data{"key": tkn.ID})
 
 	return nil
 }
 
-func (c *NOPCache) GetToken(token string) (time.Duration, error) {
+func (c *NOPCache) GetToken(ctx context.Context, token string) (time.Duration, error) {
 
 	log.Info("nopcache: get token", log.Data{"token": token})
 

--- a/mongo/token_store.go
+++ b/mongo/token_store.go
@@ -1,14 +1,15 @@
 package mongo
 
 import (
+	"context"
 	"github.com/ONSdigital/dp-identity-api/schema"
 	"time"
 )
 
-func (m *Mongo) StoreToken(tkn schema.Token, i schema.Identity, ttl time.Duration) error {
+func (m *Mongo) StoreToken(ctx context.Context, tkn schema.Token, i schema.Identity, ttl time.Duration) error {
 	return nil
 }
 
-func (m *Mongo) GetToken(tokenStr string) (time.Duration, error) {
+func (m *Mongo) GetToken(ctx context.Context, tokenStr string) (time.Duration, error) {
 	return time.Second * 0, nil
 }

--- a/persistence/models.go
+++ b/persistence/models.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"context"
 	"errors"
 	"github.com/ONSdigital/dp-identity-api/schema"
 	"time"
@@ -20,6 +21,6 @@ type IdentityStore interface {
 }
 
 type TokenStore interface {
-	StoreToken(token schema.Token, i schema.Identity, ttl time.Duration) error
-	GetToken(token string) (time.Duration, error)
+	StoreToken(ctx context.Context, token schema.Token, i schema.Identity, ttl time.Duration) error
+	GetToken(ctx context.Context, token string) (time.Duration, error)
 }

--- a/persistence/token_db_wrapper.go
+++ b/persistence/token_db_wrapper.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"context"
 	"github.com/ONSdigital/dp-identity-api/schema"
 	"time"
 )
@@ -8,26 +9,26 @@ import (
 var nilID = ""
 
 type Cache interface {
-	StoreToken(tkn schema.Token, i schema.Identity, ttl time.Duration) error
-	GetToken(token string) (time.Duration, error)
+	StoreToken(ctx context.Context, tkn schema.Token, i schema.Identity, ttl time.Duration) error
+	GetToken(ctx context.Context, token string) (time.Duration, error)
 }
 type CachedTokenStored struct {
 	Cache   Cache
 	TokenDB TokenStore
 }
 
-func (c *CachedTokenStored) StoreToken(tkn schema.Token, i schema.Identity, ttl time.Duration) error {
+func (c *CachedTokenStored) StoreToken(ctx context.Context, tkn schema.Token, i schema.Identity, ttl time.Duration) error {
 
 	// c.Cache.StoreToken() .. etc
 	// implemented this sprint - for now we'll just fall through
 
-	return c.TokenDB.StoreToken(tkn, i, ttl)
+	return c.TokenDB.StoreToken(ctx, tkn, i, ttl)
 }
 
-func (c *CachedTokenStored) GetToken(tokenStr string) (time.Duration, error) {
+func (c *CachedTokenStored) GetToken(ctx context.Context, tokenStr string) (time.Duration, error) {
 
 	// c.Cache.GetToken() ... etc
 	// implemented this sprint - for now we'll just fall through
 
-	return c.TokenDB.GetToken(tokenStr)
+	return c.TokenDB.GetToken(ctx, tokenStr)
 }


### PR DESCRIPTION
Updated the `TokenStore` interfaces to take `context` as the first param.